### PR TITLE
Add launcher motors states and automated power control

### DIFF
--- a/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/CompetitionBotConfig.java
+++ b/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/CompetitionBotConfig.java
@@ -48,6 +48,9 @@ public class CompetitionBotConfig {
     public List<DcMotor> rightMotors = new ArrayList<>();
 
     public List<DcMotor> launcherMotors = new ArrayList<>();
+    public enum LauncherMotorsState {
+        DISABLE, IDLE, LAUNCH
+    }
 
     public CRServo feederServo;
 
@@ -96,5 +99,25 @@ public class CompetitionBotConfig {
 
         DcMotorUtil.setMotorsDirection(this.leftMotors, DcMotorSimple.Direction.FORWARD);
         DcMotorUtil.setMotorsDirection(this.rightMotors, DcMotorSimple.Direction.REVERSE);
+    }
+
+    public double setLauncherState(LauncherMotorsState state) {
+        double launcherMotorIdlePower = 0.2;
+        double launcherMotorLaunchPower = 0.6;
+
+        // Default launcher speed:
+        double launcherPower = 0;
+        if (state == LauncherMotorsState.IDLE){
+            // Set the launcher power to idle mode:
+            launcherPower = launcherMotorIdlePower;
+        } else if (state == LauncherMotorsState.LAUNCH) {
+            // Set the launcher power to launch mode:
+            launcherPower = launcherMotorLaunchPower;
+        }
+
+        // Set the launcher Motors:
+        DcMotorUtil.setMotorsPower(this.launcherMotors, launcherPower);
+
+        return launcherPower;
     }
 }


### PR DESCRIPTION
The ‘gamepad2.x’ button is used to toggle the launcher on and off. After the launcher has been activated and ‘gamepad2.a’ is held, the power is set to launching speed. If the button is let go of, it will return to idling power.