### PR TITLE
Add ball loading detection and advanced control

### DIFF
--- a/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/CompetitionBotConfig.java
+++ b/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/CompetitionBotConfig.java
@@ -4,6 +4,7 @@ import com.qualcomm.robotcore.hardware.CRServo;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.OpticalDistanceSensor;
 import com.qualcomm.robotcore.hardware.Servo;
 
 import org.wheelerschool.robotics.library.util.DcMotorUtil;
@@ -54,6 +55,8 @@ public class CompetitionBotConfig {
 
     public CRServo feederServo;
 
+    public OpticalDistanceSensor feedDetector;
+
     public CompetitionBotConfig(HardwareMap hardwareMap) {
         this(hardwareMap, defaultRobotForwards);
     }
@@ -86,6 +89,8 @@ public class CompetitionBotConfig {
 
         // Launcher Feed Servo:
         feederServo = hardwareMap.crservo.get("feeder");
+
+        feedDetector = hardwareMap.opticalDistanceSensor.get("feedDetector");
     }
 
     public void setRobotDirection(boolean forwards) {


### PR DESCRIPTION
The feed servo is now controlled by holding down the ‘gamepad2.b’
button. The feeder servo will stop if the feed detector is tripped, or
the button is released. This means that the feeder will stop if a ball
is fed, to prevent a multi load. It can be started again by pushing the
button.