### PR TITLE
Add collector toggle to competition bot TeleOp

### DIFF
--- a/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/teleop/CompetitionBotTeleOp.java
+++ b/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/teleop/CompetitionBotTeleOp.java
@@ -39,6 +39,7 @@ public class CompetitionBotTeleOp extends LinearOpMode {
     // Beacon Pushers:
 
     // Collector Motors:
+    private JoystickButtonUpdated collectorMotorsActivateButton;
     private double collectorMotorsSpeed = -1;
     private double collectorMotorsReleaseSpeed = 1;
     private List<DcMotor> collectorMotors;
@@ -64,6 +65,12 @@ public class CompetitionBotTeleOp extends LinearOpMode {
         robot = new CompetitionBotConfig(hardwareMap, telemetry, null);
         robot.setUpIMU();
 
+        collectorMotorsActivateButton = new JoystickButtonUpdated(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return gamepad1.right_bumper;
+            }
+        }, false);
         robotDirectionReveseButton = new JoystickButtonUpdated(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
@@ -100,11 +107,17 @@ public class CompetitionBotTeleOp extends LinearOpMode {
 
         while (opModeIsActive()) {
             // Collector Motors:
-            if (gamepad1.right_bumper) {
-                DcMotorUtil.setMotorsPower(collectorMotors, collectorMotorsSpeed);
-            } else if (gamepad1.left_bumper) {
+            //  Get button data:
+            JoystickButtonUpdated.JoystickButtonData collectorActivateData
+                    = collectorMotorsActivateButton.getValueIgnoreException();
+
+            //  If the gamepad1.left_bumper is held, reverse the collector and disable the intake:
+            if (gamepad1.left_bumper) {
+                collectorMotorsActivateButton.lastFlipStateValue = false;
                 DcMotorUtil.setMotorsPower(collectorMotors, collectorMotorsReleaseSpeed);
-            } else {
+            } else if (collectorActivateData.flipStateValue) {  // If the intake is enabled, set power:
+                DcMotorUtil.setMotorsPower(collectorMotors, collectorMotorsSpeed);
+            } else {  // Else, disable the collector:
                 DcMotorUtil.setMotorsPower(collectorMotors, 0);
             }
 

--- a/WheelerRobotics/src/main/java/org/wheelerschool/robotics/library/util/joystick/JoystickButtonUpdated.java
+++ b/WheelerRobotics/src/main/java/org/wheelerschool/robotics/library/util/joystick/JoystickButtonUpdated.java
@@ -18,7 +18,7 @@ public class JoystickButtonUpdated {
     private boolean lastButtonState;
 
     // The value of the state flip each *new* button press:
-    private boolean lastFlipStateValue;
+    public boolean lastFlipStateValue;
 
 
     public JoystickButtonUpdated(Callable<Boolean> getButton) {


### PR DESCRIPTION
The intake button now acts as a toggle (click on, click off). If the collector reverse is enabled, the intake will also be disabled (so that it doesn't re-enable after the button is released).