### PR TITLE
Add motor servo initialization to competition robot config

### DIFF
--- a/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/CompetitionBotConfig.java
+++ b/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/CompetitionBotConfig.java
@@ -129,10 +129,12 @@ public class CompetitionBotConfig {
         this.pusherLeft = new AdvancedServo(hardwareMap.servo.get("pusherLeft"));
         this.pusherLeft.retractedPos = 0;
         this.pusherLeft.extendedPos = 1;
+        this.pusherLeft.activatePusher(false);
         this.pusherRight = new AdvancedServo(hardwareMap.servo.get("pusherRight"));
         this.pusherRight.servo.setDirection(Servo.Direction.REVERSE);
         this.pusherRight.retractedPos = 0;
         this.pusherRight.extendedPos = 1;
+        this.pusherRight.activatePusher(false);
 
         // Drive Motors:
         this.leftMotors.add(this.hardwareMap.dcMotor.get("backLeft"));
@@ -142,14 +144,17 @@ public class CompetitionBotConfig {
 
         DcMotorUtil.setMotorsRunMode(this.leftMotors, DcMotor.RunMode.RUN_USING_ENCODER);
         DcMotorUtil.setMotorsRunMode(this.rightMotors, DcMotor.RunMode.RUN_USING_ENCODER);
+        this.idleMotors();
 
         // Launcher Motors:
         launcherMotors.add(hardwareMap.dcMotor.get("launcherLeft"));
         launcherMotors.add(hardwareMap.dcMotor.get("launcherRight"));
         DcMotorUtil.setMotorsDirection(launcherMotors, DcMotorSimple.Direction.REVERSE);
+        this.setLauncherState(LauncherMotorsState.DISABLE);
 
         // Launcher Feed Servo:
         feederServo = hardwareMap.crservo.get("feeder");
+        feederServo.setPower(0);
 
         feedDetector = hardwareMap.opticalDistanceSensor.get("feedDetector");
 

--- a/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/autonomous/CompetitionBotAutonomous.java
+++ b/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/autonomous/CompetitionBotAutonomous.java
@@ -76,9 +76,6 @@ public abstract class CompetitionBotAutonomous extends LinearOpMode {
         robot = new CompetitionBotConfig(hardwareMap, telemetry, false, new LinearOpModeActiveCallable(this));
         robot.setUpIMU();
 
-        //      Reset Beacon Pushers:
-        robot.pusherLeft.activatePusher(false);
-        robot.pusherRight.activatePusher(false);
         //      Motors (for reference in extending an class to set the closer and farther motors):
         this.leftMotors.addAll(robot.leftMotors);
         this.rightMotors.addAll(robot.rightMotors);


### PR DESCRIPTION
The motor and servo power/position values are set to "zero" on construction of the robot config class.