### PR TITLE
Add encoder ramp down to IMU drive

### DIFF
--- a/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/CompetitionBotConfig.java
+++ b/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/CompetitionBotConfig.java
@@ -211,6 +211,16 @@ public class CompetitionBotConfig {
         DcMotorUtil.setMotorsPower(this.rightMotors, 0);
     }
 
+    public void resetEncoders() throws InterruptedException {
+        // Reset Encoders:
+        DcMotorUtil.setMotorsRunMode(this.leftMotors, DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        DcMotorUtil.setMotorsRunMode(this.rightMotors, DcMotor.RunMode.STOP_AND_RESET_ENCODER);
+        Thread.sleep(50);  // Wait for reset to occur...
+        // Change mode to run using the encoders:
+        DcMotorUtil.setMotorsRunMode(this.leftMotors, DcMotor.RunMode.RUN_USING_ENCODER);
+        DcMotorUtil.setMotorsRunMode(this.rightMotors, DcMotor.RunMode.RUN_USING_ENCODER);
+    }
+
     private Boolean __runBooleanCallableIgnoreException(Callable<Boolean> func) {
         try {
             return func.call();
@@ -267,13 +277,7 @@ public class CompetitionBotConfig {
     }
 
     public void driveForwardByEncoder(double motorPower, double differentialGain, long encoderVal) throws InterruptedException {
-        // Reset Encoders:
-        DcMotorUtil.setMotorsRunMode(this.leftMotors, DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-        DcMotorUtil.setMotorsRunMode(this.rightMotors, DcMotor.RunMode.STOP_AND_RESET_ENCODER);
-        Thread.sleep(50);  // Wait for reset to occur...
-        // Change mode to run using the encoders:
-        DcMotorUtil.setMotorsRunMode(this.leftMotors, DcMotor.RunMode.RUN_USING_ENCODER);
-        DcMotorUtil.setMotorsRunMode(this.rightMotors, DcMotor.RunMode.RUN_USING_ENCODER);
+        resetEncoders();
 
         // Log the info:
         Log.i(AUTO_FULL_LOG_TAG, "RESET LEFT/RIGHT MOTOR ENCODERS");

--- a/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/autonomous/CompetitionBotAutonomous.java
+++ b/WheelerRobotics/src/main/java/org/wheelerschool/robotics/competitionbot/autonomous/CompetitionBotAutonomous.java
@@ -150,7 +150,7 @@ public abstract class CompetitionBotAutonomous extends LinearOpMode {
 
             // Follow the wall:
             Log.i(AUTO_STATE_LOG_TAG, "\"Follow\" the wall! (use IMU to drive straight)");
-            robot.driveForwardByIMU(0, ROBOT_ROTATION_GAIN, 0.8);
+            robot.driveForwardByIMU(0, ROBOT_ROTATION_GAIN, 0.8, 5000, 0.4);
             Log.i(AUTO_STATE_LOG_TAG, "DETECTED LINE (HOPEFULLY THE SECOND BEACON'S)!");
 
             Thread.sleep(100);


### PR DESCRIPTION
An (optional) encoder ramp down to the IMU drive method in the robot config. A ramp down encoder tick distance and speed can be inputted to enable this.